### PR TITLE
Show user links to poll and results

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@ const app = express();
 const http = require('http').Server(app);
 const io = require('socket.io')(http);
 const redis = require('redis');
-
 const path = require('path');
 const client = redis.createClient();
 
 const bodyParser = require('body-parser');
+
+const Poll = require('./lib/poll');
 
 const pry = require('pryjs');
 
@@ -20,8 +21,13 @@ app.get('/', function (req, res){
 });
 
 app.post('/poll', function (req, res) {
-  console.log('Poll received with ' + JSON.stringify(req.body));
-  res.send('You submited ' + req.body.question + '.');
+  var newPoll = new Poll(req.body);
+  var pollLink = `${req.headers.host}/${newPoll.id}`;
+  res.send(`
+      <p>You submited: ${req.body.question}<p>
+      <p>Poll link: <a href="${pollLink}">${pollLink}</a></p>
+      <p>Results link: <a href="${pollLink}/admin">${pollLink}/admin</a></p>
+      `);
 });
 
 http.listen(process.env.PORT || 3000, function(){

--- a/lib/poll.js
+++ b/lib/poll.js
@@ -1,0 +1,7 @@
+const md5 = require('md5');
+
+function Poll (data) {
+  this.id = md5( JSON.stringify(data) + Date.now() );
+}
+
+module.exports = Poll;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "body-parser": "^1.14.1",
     "express": "^4.12.3",
+    "md5": "^2.0.0",
     "redis": "^2.3.0",
     "socket.io": "^1.3.5"
   },


### PR DESCRIPTION
Why:
- After a user creates a poll he should be shown two links: 1) a link to
  share with voters and 2) a link where the administrator can see the
  results

This change addresses the need by:
- Creating a Poll class that generates a unique id upon instantiation.
- Creating a new Poll object when a post request is received on /poll
  route.
- Showing the user a unique link to the created poll to  share with voters and to track
  results.
