### PR TITLE
Add dynamic poll routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,14 +20,37 @@ app.get('/', function (req, res){
   res.sendFile(path.join(__dirname, '/public/index.html'));
 });
 
-app.post('/poll', function (req, res) {
+app.post('/polls', function (req, res) {
   var newPoll = new Poll(req.body);
-  var pollLink = `${req.headers.host}/${newPoll.id}`;
+  client.hmset('polls', newPoll.id, JSON.stringify(newPoll));
+  var pollLink = `${req.headers.host}/polls/${newPoll.id}`;
   res.send(`
       <p>You submited: ${req.body.question}<p>
-      <p>Poll link: <a href="${pollLink}">${pollLink}</a></p>
-      <p>Results link: <a href="${pollLink}/admin">${pollLink}/admin</a></p>
+      <p>Poll link: <a href="http://${pollLink}">${pollLink}</a></p>
+      <p>Results link: <a href="http://${pollLink}/admin">${pollLink}/admin</a></p>
       `);
+});
+
+app.get('/polls/:id', function (req, res) {
+  client.hgetall('polls', function (err, obj) {
+    var poll = JSON.parse(obj[req.params.id]);
+    res.send(`
+        <p>${poll.question}</p>
+        <p>${poll.answers[0]}</p>
+        <p>${poll.answers[1]}</p>
+        `);
+  });
+});
+
+app.get('/polls/:id/admin', function (req, res) {
+  client.hgetall('polls', function (err, obj) {
+    var poll = JSON.parse(obj[req.params.id]);
+    res.send(`
+        <p>${poll.question}</p>
+        <p>${poll.answers[0]}</p>
+        <p>${poll.answers[1]}</p>
+        `);
+  });
 });
 
 http.listen(process.env.PORT || 3000, function(){

--- a/lib/poll.js
+++ b/lib/poll.js
@@ -2,6 +2,8 @@ const md5 = require('md5');
 
 function Poll (data) {
   this.id = md5( JSON.stringify(data) + Date.now() );
+  this.question = data.question;
+  this.answers = data.answers;
 }
 
 module.exports = Poll;

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <p>Create a poll, share it with others and see the results in real time.</p>
     <button id="btn-create-poll">Create a Poll</button>
 
-    <form id="poll-form" action="/poll" method="post">
+    <form id="poll-form" action="/polls" method="post">
 
       <label for="question">Question</label><br>
       <input id="question" type="text" name="question"><br>


### PR DESCRIPTION
Why:
- A user should be able to visit the links generated when a poll is
  created.

This change addresses the need by:
- Add /polls/:id route that displays poll for a given id
- Add /polls/:id/admin route that displays poll for a given id

Other
- Change routes that were previously singular to plural (poll to polls)
