### PR TITLE
Add controller tests for /polls and /polls/:id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+dump.rdb

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "crowdsource",
   "version": "1.0.0",
-  "description": "Real time pol application.",
-  "main": "index.js",
+  "description": "Real time poll application.",
+  "main": "server.js",
   "scripts": {
-    "start": "./node_modules/nodemon/bin/nodemon.js index.js",
+    "start": "./node_modules/nodemon/bin/nodemon.js server.js",
     "test": "mocha"
   },
   "author": "Sebastian Abondano",
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "mocha": "^2.3.3",
-    "nodemon": "^1.3.7"
+    "nodemon": "^1.3.7",
+    "pryjs": "^0.1.3",
+    "request": "^2.65.0"
   }
 }

--- a/public/application.js
+++ b/public/application.js
@@ -17,6 +17,6 @@
   // Add answer field to form when #btn-add-answer is clicked.
   addChoiceButton.on('click', function (event) {
     event.preventDefault();
-    choices.append(`<input type="text" name="choices"><br>`);
+    choices.append(`<input type="text" name="poll[choices]"><br>`);
   });
 }());

--- a/public/index.html
+++ b/public/index.html
@@ -13,12 +13,12 @@
     <form id="poll-form" action="/polls" method="post">
 
       <label for="question">Question</label><br>
-      <input id="question" type="text" name="question"><br>
+      <input id="question" type="text" name="poll[question]"><br>
 
       <div id="choices">
         <label for="choices">Answers</label><br>
-        <input type="text" name="choices"><br>
-        <input type="text" name="choices"><br>
+        <input type="text" name="poll[choices]"><br>
+        <input type="text" name="poll[choices]"><br>
       </div>
 
       <a href="" id="btn-add-choice">Add Answer</a>

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,4 @@
+exports.validPoll = {
+  question: 'To be or not to be?',
+  choices: [ 'yes', 'no' ]
+};

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -1,0 +1,114 @@
+const assert = require('assert');
+const request = require('request');
+const app = require('../server');
+const redis = require('redis');
+const client = redis.createClient();
+
+const fixtures = require('./fixtures');
+const Poll = require('../lib/poll');
+
+const pry = require('pryjs');
+
+describe('Server', () => {
+
+  before((done) => {
+    this.port = 9876;
+
+    this.server = app.listen(this.port, (err, result) => {
+      if (err) { return done(err); }
+      done();
+    });
+
+    this.request = request.defaults({
+      baseUrl: 'http://localhost:9876/'
+    });
+  });
+
+  after(() => {
+    this.server.close();
+  });
+
+  it('should exist', () => {
+    assert(app);
+  });
+
+  describe('GET /', () => {
+
+    it('should return a 200', (done) => {
+      this.request.get('/', (error, response) => {
+        if (error) { done(error); }
+        assert.equal(response.statusCode, 200);
+        done();
+      });
+    });
+
+    it('should have a body with the name of the application', (done) => {
+      var title = app.locals.title;
+
+      this.request.get('/', (error, response) => {
+        if (error) { done(error); }
+        assert(response.body.includes(title),
+               `"${response.body}" does not include "${title}".`);
+        done();
+      });
+    });
+
+  });
+
+  describe('POST /polls', () => {
+
+    beforeEach(() => {
+      client.flushall();
+    });
+
+    it('should not return 404', (done) => {
+      this.request.post('/polls', (error, response) => {
+        if (error) { done(error); }
+        assert.notEqual(response.statusCode, 404);
+        done();
+      });
+    });
+
+    it('should receive and store data', (done) => {
+      var payload = { poll: fixtures.validPoll };
+
+      this.request.post('/polls', { form: payload }, (error, response) => {
+        if (error) { done(error); }
+
+        var pollCount = Object.keys(client.hgetall("polls")).length;
+        client.hgetall('polls', function (err, obj) {
+          var pollCount = Object.keys(obj).length;
+          assert.equal(pollCount, 1, `Expected 1 poll, found ${pollCount}`);
+        });
+
+        done();
+      });
+    });
+
+  });
+
+  describe('GET /polls/:id', () => {
+
+    it('should not return 404', (done) => {
+      this.request.get('/polls/testPoll', (error, response) => {
+        if (error) { done(error); }
+        assert.notEqual(response.statusCode, 404);
+        done();
+      });
+    });
+
+    it('should return a page that has the question for the given poll', (done) => {
+      var newPoll = new Poll({pollData: fixtures.validPoll, host: 'whateves'});
+      client.hmset('polls', newPoll.id, JSON.stringify(newPoll));
+
+      this.request.get('/polls/' + newPoll.id, (error, response) => {
+        if (error) { done(error); }
+        assert(response.body.includes(newPoll.question),
+               `"${response.body}" does not include "${newPoll.question}".`);
+               done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
Why:
- Because tests are awesome.

This change addresses the need by:
- Other than testing POST /polls and GET /polls/:id the only change to note is
  that the poll data submitted on POST /polls now comes in nested under the key of
  'poll'. This makes it easier to test and it's also more readable.
