### PR TITLE
Feature: allows user to share results with voters

### DIFF
--- a/lib/poll.js
+++ b/lib/poll.js
@@ -10,6 +10,7 @@ function Poll (data, existingPollFlag) {
     this.question  = data.pollData.question;
     this.choices   = data.pollData.choices;
     this.votes     = {}; 
+    this.shareable = !!data.pollData.shareable;
   } else {
     this.id        = data.id;
     this.adminId   = data.adminId;
@@ -18,6 +19,7 @@ function Poll (data, existingPollFlag) {
     this.question  = data.question;
     this.choices   = data.choices;
     this.votes     = data.votes; 
+    this.shareable = data.shareable;
   }
 }
 

--- a/public/application.js
+++ b/public/application.js
@@ -19,4 +19,5 @@
     event.preventDefault();
     choices.append(`<input type="text" name="poll[choices]"><br>`);
   });
+
 }());

--- a/public/client.js
+++ b/public/client.js
@@ -25,5 +25,5 @@ var tally = document.getElementById('tally');
 
 socket.on('voteCount', function (votes) {
   console.log(votes);
-  tally.innerText = JSON.stringify(votes);
+  if (tally) { tally.innerText = JSON.stringify(votes); }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
 
     <form id="poll-form" action="/polls" method="post">
 
-      <label for="question">Question</label><br>
+      <label for="poll[question]">Question</label><br>
       <input id="question" type="text" name="poll[question]"><br>
 
       <div id="choices">
@@ -20,6 +20,13 @@
         <input type="text" name="poll[choices]"><br>
         <input type="text" name="poll[choices]"><br>
       </div>
+
+      <label for="shareable">
+        <input type="checkbox" id="shareable" value="true" name="poll[shareable]">
+        Share results with voters.
+      </label>
+      
+      <br>
 
       <a href="" id="btn-add-choice">Add Answer</a>
       <input type="submit" value="Submit">

--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ app.get('/polls/:id', function (req, res) {
     }
     
     var poll = new Poll(JSON.parse(obj[req.params.id]), 'existingPoll');
-    res.render('pages/poll-show', {poll: poll, admin: false});
+    res.render('pages/poll-show', {poll: poll});
   });
 });
 
@@ -55,11 +55,10 @@ app.get('/polls/:id/admin', function (req, res) {
       var parsedPoll = JSON.parse(obj[poll]);
       if (parsedPoll.adminId === req.params.id) {
         var instantiatedPoll = new Poll(parsedPoll, 'existingPoll');
-        res.render('pages/poll-show', {poll: instantiatedPoll, admin: true});
-      } else {
-        return res.send(`No poll with id ${req.params.id} found.`);
-      }
+        return res.render('pages/admin/poll-show', {poll: instantiatedPoll});
+      } 
     }
+    res.send(`No poll with id ${req.params.id} found.`);
   });
 });
 
@@ -76,7 +75,7 @@ io.on('connection', function (socket) {
         var poll = new Poll(JSON.parse(obj[message.pollId]), 'existingPoll');
         poll.votes[socket.id] =  message.vote;
         client.hmset('polls', poll.id, JSON.stringify(poll));
-        // io.sockets.emit('voteCount', poll.countVotes());
+        io.sockets.emit('voteCount', poll.countVotes());
         socket.emit('statusMessage', `We received your vote for ${message.vote}!`);
       });
     }

--- a/views/pages/admin/poll-show.ejs
+++ b/views/pages/admin/poll-show.ejs
@@ -19,11 +19,9 @@
   </div>
 </div>
 
-<% if (poll.shareable) { %>
-  <div id="tally">
-    <%= JSON.stringify(poll.countVotes()) %>
-  </div>
-<% } %>
+<div id="tally">
+  <%= JSON.stringify(poll.countVotes()) %>
+</div>
 
 </main>
 


### PR DESCRIPTION
Why:
- Per spec, a user should be able to share results with voters if he
  desires to do so.

This change addresses the need by:
- Adding shareable attribute to Poll class.
- Adding shareable checkbox to new poll form.
- Modifying socket listener on 'voteCount' to only update tally if tally
  div exists on page (only admin or shareable polls will have it).
- Adding an admin/poll-show view to more easily adapt view for admin
  pages.
- Modify poll show view to show tally if poll is shareable.
