### PR TITLE
Add feature for admin to turn poll off

### DIFF
--- a/lib/poll.js
+++ b/lib/poll.js
@@ -11,6 +11,7 @@ function Poll (data, existingPollFlag) {
     this.choices   = data.pollData.choices;
     this.votes     = {}; 
     this.shareable = !!data.pollData.shareable;
+    this.status    = "on";
   } else {
     this.id        = data.id;
     this.adminId   = data.adminId;
@@ -20,6 +21,7 @@ function Poll (data, existingPollFlag) {
     this.choices   = data.choices;
     this.votes     = data.votes; 
     this.shareable = data.shareable;
+    this.status    = data.status;
   }
 }
 

--- a/public/client.js
+++ b/public/client.js
@@ -15,11 +15,22 @@ socket.on('statusMessage', function (message) {
 var pollId = document.getElementById('poll').dataset.id;
 var buttons = document.querySelectorAll('#choices button');
 
+var voteCastListener = function () {
+  socket.send('voteCast', {pollId: pollId, vote: this.innerText});
+};
+
 for (var i = 0; i < buttons.length; i++) {
-  buttons[i].addEventListener('click', function () {
-    socket.send('voteCast', {pollId: pollId, vote: this.innerText});
-  });
+  buttons[i].addEventListener('click', voteCastListener);
 }
+
+var btnEndPoll = document.getElementById('btn-end-poll');
+
+btnEndPoll.addEventListener('click', function () {
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].removeEventListener('click', voteCastListener);
+  }    
+  socket.send('turnPollOff', {pollId: pollId});
+});
 
 var tally = document.getElementById('tally');
 

--- a/views/pages/admin/poll-show.ejs
+++ b/views/pages/admin/poll-show.ejs
@@ -23,6 +23,8 @@
   <%= JSON.stringify(poll.countVotes()) %>
 </div>
 
+<button id="btn-end-poll">Turn Poll Off</button>
+
 </main>
 
 <footer>
@@ -31,5 +33,6 @@
 <script src="/jquery.js"></script>
 <script src="/socket.io/socket.io.js"></script>
 <script src="/client.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Why:
- Per spec, an admin should be able to turn off a poll from the admin
  poll show view. Once off the poll shouldn't record any more votes.

This change addresses the need by:
- Adding a status attribute to Poll class.
- Adding a 'Turn Off' button to admin poll show view.
- Adding a socket listener to the turn off button that sends the poll's
  id to the server and the server changes status of poll to off
- Modifying socket listener on voteCast channel to only record votes if
  poll's status is on and send a message saying poll is off if poll's
  status id off
